### PR TITLE
Use 8 GB volumes by default, make it configurable. Change AMI updating logic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_launch_template" "nat_instance" {
     device_name = tolist(data.aws_ami.nat.block_device_mappings)[0].device_name
 
     ebs {
-      volume_size = 30
+      volume_size = var.instance_volume_size
       volume_type = "gp3"
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -78,9 +78,9 @@ resource "aws_launch_template" "nat_instance" {
     tags          = merge(tomap({ "Name" = "${var.name}-${substr(data.aws_subnet.nat_all[each.key].availability_zone, -2, -1)}" }), var.tags)
   }
   
-  lifecycle {
-    ignore_changes = [user_data, image_id]
-  }
+  # lifecycle {
+  #   ignore_changes = [user_data, image_id]
+  # }
 }
 
 locals {
@@ -115,6 +115,10 @@ resource "aws_autoscaling_group" "nat_instance" {
   launch_template {
     id      = aws_launch_template.nat_instance[each.key].id
     version = aws_launch_template.nat_instance[each.key].latest_version
+  }
+
+  instance_refresh {
+    strategy = "Rolling"
   }
 
   tag {

--- a/templates/userdata.tftpl
+++ b/templates/userdata.tftpl
@@ -4,7 +4,7 @@
 sed -i "s/#\$nrconf{kernelhints} = -1;/\$nrconf{kernelhints} = -1;/g" /etc/needrestart/needrestart.conf
 sed -i "/#\$nrconf{restart} = 'i';/s/.*/\$nrconf{restart} = 'a';/" /etc/needrestart/needrestart.conf
 
-apt update -y && apt upgrade -y && apt install -y ifupdown
+apt update -y && apt install -y ifupdown
 
 sysctl -w net.ipv4.ip_forward=1 && \
 echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.conf
@@ -16,7 +16,7 @@ if [[ $(/usr/sbin/iptables -t nat -L) != *"MASQUERADE"* ]]; then
 fi
 ' | /usr/bin/tee /etc/network/if-pre-up.d/nat-setup && \
 chmod +x /etc/network/if-pre-up.d/nat-setup && \
-/etc/network/if-pre-up.d/nat-setup 
+/etc/network/if-pre-up.d/nat-setup
 
 systemctl disable ssh --now
-reboot
+# reboot

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "instance_type" {
   default     = "t4g.nano"
 }
 
+variable "instance_volume_size" {
+  type        = number
+  description = "Default volume size for NAT instances"
+  default     = 8
+}
+
 variable "ami" {
   description = "AMI for nat instance"
   type        = string


### PR DESCRIPTION
I couldn't see the reason for using 30GB volumes in NAT instances, so made a variable and updated it to be 8 by default to save costs.

Also, while trying it - the changes didn't work at first, so I've updated the user_data script to not perform apt upgrade and keep packages as provided by AMI, and at the same time updated resources to perform instance refresh on AMI or user_data changes.